### PR TITLE
Day 1: Trebuchet?! Cleanup

### DIFF
--- a/days/01/mod.ts
+++ b/days/01/mod.ts
@@ -18,26 +18,34 @@ const spelledOutDigits: Map<string, string> = new Map([
 	['nine', '9'],
 ]);
 
+export function matchDigits(
+	calibration: string,
+	withSpelledOutDigits: boolean
+) {
+	const matcher = new RegExp(
+		`(?=(\\d${
+			withSpelledOutDigits ? '|' + [...spelledOutDigits.keys()].join('|') : ''
+		}))`,
+		'g'
+	);
+
+	return Array.from(
+		calibration.matchAll(matcher),
+		([, match]) => spelledOutDigits.get(match) || match
+	);
+}
+
 export function getCalibrationValues(
 	calibrations: string[],
 	withSpelledOutDigits: boolean
 ) {
-	const digitsMatcher = withSpelledOutDigits
-		? new RegExp(`(?=(\\d|${[...spelledOutDigits.keys()].join('|')}))`, 'g')
-		: /(?=(\d))/g;
-
 	return calibrations.map((calibration) => {
-		const digits = Array.from(
-			[...calibration.matchAll(digitsMatcher)],
-			(match) => match[1]
-		);
+		const {
+			length,
+			0: firstDigit,
+			[length - 1]: lastDigit,
+		} = matchDigits(calibration, withSpelledOutDigits);
 
-		if (!digits.length) return 0;
-
-		const firstDigit = spelledOutDigits.get(digits.at(0)!) || digits.at(0)!;
-
-		const lastDigit = spelledOutDigits.get(digits.at(-1)!) || digits.at(-1)!;
-
-		return +(firstDigit + lastDigit);
+		return length ? +(firstDigit + lastDigit) : 0;
 	});
 }

--- a/days/01/mod_test.ts
+++ b/days/01/mod_test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { getCalibrationValues, getInput } from './mod';
+import { getCalibrationValues, getInput, matchDigits } from './mod';
 
 describe('Day 1: Trebuchet?!', async () => {
 	test('Get input', async () => {
@@ -20,17 +20,18 @@ describe('Day 1: Trebuchet?!', async () => {
 		]);
 	});
 
-	const firstCalibrations = await getInput('./input_test.1.txt');
+	test('Match digits', () => {
+		expect(matchDigits('1two3four', false)).toEqual(['1', '3']);
+		expect(matchDigits('1two3four', true)).toEqual(['1', '2', '3', '4']);
+	});
 
-	test('Get calibration values (w/o spelled out numbers)', () => {
+	const firstCalibrations = await getInput('./input_test.1.txt');
+	const secondCalibrations = await getInput('./input_test.2.txt');
+
+	test('Get calibration values', () => {
 		expect(getCalibrationValues(firstCalibrations, false)).toEqual([
 			12, 38, 15, 77,
 		]);
-	});
-
-	const secondCalibrations = await getInput('./input_test.2.txt');
-
-	test('Get calibration values (w/ spelled out numbers):', () => {
 		expect(getCalibrationValues(secondCalibrations, true)).toEqual([
 			29, 83, 13, 24, 42, 14, 76,
 		]);


### PR DESCRIPTION
Cleans up some of the code for the completed day 1 challenge. This includes:

1. Breaking out digit matching and reformatting into a `matchDigits` function.
2. Building out the digit matching regular expression from a string for both with and without spelled out digits.
3. Using object destructuring to pull the first/last digits (to avoid non-null Typescript assertions).
4. Reorganizing the module tests to include new tests for the `matchDigits` function as well as group variations under the same test (instead of breaking them out into distinct tests, i.e. one test per one exported function).