### PR TITLE
Day 2: Cube Conundrum Cleanup

### DIFF
--- a/days/02/mod_test.ts
+++ b/days/02/mod_test.ts
@@ -3,113 +3,100 @@ import {
 	getInput,
 	getMinimumCubeSetPowers,
 	getPossibleGameIDs,
-	matchCubes,
+	getCubeSet,
 } from './mod';
 
 describe('Day 2: Cube Conundrum', async () => {
 	test('Match cubes', () => {
 		const set = '8 green, 6 blue, 20 red';
-		expect(matchCubes('red', set)).toBe(20);
-		expect(matchCubes('green', set)).toBe(8);
-		expect(matchCubes('blue', set)).toBe(6);
+		expect(getCubeSet(set)).toEqual({
+			green: 8,
+			blue: 6,
+			red: 20,
+		});
 	});
 
 	test('Get input', async () => {
-		expect([...(await getInput('./input_test.txt')).entries()]).toEqual([
+		expect(await getInput('./input_test.txt')).toEqual([
 			[
-				1,
-				[
-					{
-						blue: 3,
-						red: 4,
-						green: 0,
-					},
-					{
-						red: 1,
-						green: 2,
-						blue: 6,
-					},
-					{
-						green: 2,
-						red: 0,
-						blue: 0,
-					},
-				],
+				{
+					blue: 3,
+					red: 4,
+					green: 0,
+				},
+				{
+					red: 1,
+					green: 2,
+					blue: 6,
+				},
+				{
+					green: 2,
+					red: 0,
+					blue: 0,
+				},
 			],
 			[
-				2,
-				[
-					{
-						blue: 1,
-						green: 2,
-						red: 0,
-					},
-					{
-						green: 3,
-						blue: 4,
-						red: 1,
-					},
-					{
-						green: 1,
-						blue: 1,
-						red: 0,
-					},
-				],
+				{
+					blue: 1,
+					green: 2,
+					red: 0,
+				},
+				{
+					green: 3,
+					blue: 4,
+					red: 1,
+				},
+				{
+					green: 1,
+					blue: 1,
+					red: 0,
+				},
 			],
 			[
-				3,
-				[
-					{
-						green: 8,
-						blue: 6,
-						red: 20,
-					},
-					{
-						blue: 5,
-						red: 4,
-						green: 13,
-					},
-					{
-						green: 5,
-						red: 1,
-						blue: 0,
-					},
-				],
+				{
+					green: 8,
+					blue: 6,
+					red: 20,
+				},
+				{
+					blue: 5,
+					red: 4,
+					green: 13,
+				},
+				{
+					green: 5,
+					red: 1,
+					blue: 0,
+				},
 			],
 			[
-				4,
-				[
-					{
-						green: 1,
-						red: 3,
-						blue: 6,
-					},
-					{
-						green: 3,
-						red: 6,
-						blue: 0,
-					},
-					{
-						green: 3,
-						blue: 15,
-						red: 14,
-					},
-				],
+				{
+					green: 1,
+					red: 3,
+					blue: 6,
+				},
+				{
+					green: 3,
+					red: 6,
+					blue: 0,
+				},
+				{
+					green: 3,
+					blue: 15,
+					red: 14,
+				},
 			],
 			[
-				5,
-				[
-					{
-						red: 6,
-						blue: 1,
-						green: 3,
-					},
-					{
-						blue: 2,
-						red: 1,
-						green: 2,
-					},
-				],
+				{
+					red: 6,
+					blue: 1,
+					green: 3,
+				},
+				{
+					blue: 2,
+					red: 1,
+					green: 2,
+				},
 			],
 		]);
 	});


### PR DESCRIPTION
Cleans up the completed code for the Day 2: Cube Conundrum challenge. This includes:

1. Adding a `colors` constant, which contains all color strings. This is then used to define the `CubeSet` type keys as well as power the next change.
2. Replacing the `matchCube` function with the `getCubeSet` function. This reduces redundancy by returning a cube set object instead of a value. This also significantly simplifies the `getInput` function.
3. Since the game IDs are not important (as they can be inferred by the index of a given array of cube sets), the `getInput` function now returns a 2D cube set array instead of a map.
4. Updates the `getMinimumCubeSetPowers` function to use a `minSet` cube set object as opposed to separate values for red, green, and blue when calculating. This also makes multiplying the values simpler.