### PR TITLE
Days 1 & 2 tests cleanup

### DIFF
--- a/days/01/mod_test.ts
+++ b/days/01/mod_test.ts
@@ -29,7 +29,7 @@ describe('Day 1: Trebuchet?!', async () => {
 	const secondCalibrations = await getInput('./input_test.2.txt');
 
 	test('Get calibration values', () => {
-		expect(getSumOfCalibrationValues(firstCalibrations, false)).toEqual(142);
-		expect(getSumOfCalibrationValues(secondCalibrations, true)).toEqual(281);
+		expect(getSumOfCalibrationValues(firstCalibrations, false)).toBe(142);
+		expect(getSumOfCalibrationValues(secondCalibrations, true)).toBe(281);
 	});
 });

--- a/days/02/mod_test.ts
+++ b/days/02/mod_test.ts
@@ -110,6 +110,6 @@ describe('Day 2: Cube Conundrum', async () => {
 	});
 
 	test('Get minimum cube set powers', () => {
-		expect(getSumOfMinimumCubeSetPower(games)).toEqual(2286);
+		expect(getSumOfMinimumCubeSetPower(games)).toBe(2286);
 	});
 });


### PR DESCRIPTION
Cleans up the tests for the days 1 & 2 completed code challenges to change all tests that expected an array to be returned and validated with a `toEqual` call to a `toBe` call now that these return numbers instead.